### PR TITLE
Set the userstamp to nil for updates that happen via rails console or rake tasks

### DIFF
--- a/lib/blamer/userstamp.rb
+++ b/lib/blamer/userstamp.rb
@@ -19,19 +19,18 @@ module Blamer
     end
 
     def _create_record(*args)
-      if record_userstamps && userstamp_object
-        write_attribute(created_userstamp_column, userstamp_object.id) if respond_to?(created_userstamp_column)
-        write_attribute(updated_userstamp_column, userstamp_object.id) if respond_to?(updated_userstamp_column)
+      if record_userstamps
+        write_attribute(created_userstamp_column, userstamp_object.try(:id)) if respond_to?(created_userstamp_column)
+        write_attribute(updated_userstamp_column, userstamp_object.try(:id)) if respond_to?(updated_userstamp_column)
       end
 
       super
     end
 
     def _update_record(*args)
-      if record_userstamps && userstamp_object && changed?
-        write_attribute(updated_userstamp_column, userstamp_object.id) if respond_to?(updated_userstamp_column)
+      if record_userstamps && changed?
+        write_attribute(updated_userstamp_column, userstamp_object.try(:id)) if respond_to?(updated_userstamp_column)
       end
-
       super
     end
 

--- a/test/blame_test.rb
+++ b/test/blame_test.rb
@@ -25,4 +25,24 @@ class BlameTest < Test::Unit::TestCase
     assert_equal @user2.id, @widget.updated_by
   end
 
+  def test_console_create
+    User.current_user = nil
+    another_widget = Widget.create! :name => "Ten"
+
+    assert_equal 'Ten', another_widget.name
+    assert_equal nil, another_widget.created_by
+    assert_equal nil, another_widget.updated_by
+  end
+
+  def test_console_update
+    User.current_user = nil
+    @widget.update_attribute(:name, 'Three')
+
+    @widget.reload
+
+    assert_equal 'Three', @widget.name
+    assert_equal @user1.id, @widget.created_by
+    assert_equal nil, @widget.updated_by
+  end
+
 end


### PR DESCRIPTION
It's weird that for updates happening to an object via rails console or rake tasks, we'd update the timestamps but not the userstamps. Without this patch, we'll blame the wrong user for the update.
